### PR TITLE
Add microagent for Python definition

### DIFF
--- a/.openhands/microagents/python_definition.md
+++ b/.openhands/microagents/python_definition.md
@@ -1,0 +1,6 @@
+---
+triggers:
+  - python-definition
+---
+
+Tell me about the Python definition


### PR DESCRIPTION
This pull request adds a new microagent to the `.openhands/microagents` directory.  The microagent, `python_definition.md`, provides information about Python definitions when triggered by the phrase "python-definition".