### PR TITLE
Add funny-story microagent

### DIFF
--- a/.openhands/microagents/funny-story.md
+++ b/.openhands/microagents/funny-story.md
@@ -1,0 +1,25 @@
+---
+triggers:
+- funny-story
+---
+
+# Tell me a funny story
+
+This microagent tells a funny story when triggered.
+
+## Funny Stories Collection
+
+1. **The Programmer's Dilemma**
+   A programmer was walking down the street when he saw a sign that said "Talking Dog for Sale - $10." Curious, he knocked on the door. The owner said, "The dog's in the backyard." The programmer went to the backyard and saw a normal-looking dog sitting there. "So, you can talk?" he asked skeptically. The dog replied, "Yes! I used to work for the CIA as a spy dog. I could infiltrate enemy compounds, gather intelligence, and report back. After that, I worked for NASA, helping with space missions by communicating with astronauts. Then I became a therapy dog, helping people with their problems." The programmer was amazed and went back to the owner. "Why are you selling this incredible dog for only $10?" The owner shrugged, "Because he's a liar. He's never done any of those things - he's a web developer."
+
+2. **The Magic Coffee Machine**
+   An engineer, a physicist, and a mathematician were staying in a hotel. During the night, a fire started in the engineer's room. He woke up, saw the fire, grabbed the fire extinguisher, sprayed it all over the fire, and put it out. The next night, a fire started in the physicist's room. He woke up, saw the fire, calculated the exact amount of water needed, grabbed a bucket, measured the precise amount, and put out the fire efficiently. The third night, a fire started in the mathematician's room. He woke up, saw the fire, looked around, spotted the fire extinguisher, and said, "Ah! A solution exists!" Then he went back to sleep.
+
+3. **The Tech Support Call**
+   A woman called tech support complaining that her computer wasn't working. The technician asked her to describe what happened. She said, "Well, I was typing a document when suddenly the screen went black." The technician asked, "Can you see the cursor blinking?" She replied, "What's a cursor?" The technician patiently explained, "It's the little line that blinks on your screen." After a pause, she said, "Oh, you mean the thing that looks like it's having a seizure? No, I don't see that." The technician then asked, "Is your computer plugged in?" She responded indignantly, "Of course it's plugged in! Do you think I'm stupid? I'm not some kind of idiot!" After 20 minutes of troubleshooting, the technician asked her to check if the power button was on. She said, "Oh wait, let me turn on the light so I can see better... Oh! There we go, it's working now!" There had been a power outage.
+
+4. **The Restaurant Mix-up**
+   A man walked into a restaurant and ordered a steak. The waiter brought him a plate with a tiny piece of meat on it. The man complained, "This steak is way too small!" The waiter replied, "Sir, that's not your steak, that's your bill." The man looked confused and said, "Then where's my steak?" The waiter pointed to his pocket and said, "You can't afford it, so I'm keeping it safe for you." The man laughed and said, "Well, at least the service here is honest!" Just then, another waiter came over with a huge steak and said, "Sorry sir, there was a mix-up in the kitchen. This is actually your order." The first waiter looked embarrassed and said, "Well, I guess I'll have to find a new place to store my lunch."
+
+5. **The Job Interview**
+   A man went to a job interview at a tech company. The interviewer asked, "What's your greatest weakness?" The man thought for a moment and said, "I'm too honest." The interviewer replied, "I don't think honesty is a weakness." The man said, "I don't care what you think." Despite this, he got the job because the company appreciated his direct communication style. On his first day, his boss asked him to work overtime. He said, "I'd rather not, but I will because I need this job." His boss laughed and said, "Your honesty is refreshing. Most people just make excuses." The man replied, "Well, I could make excuses too, but I'm too lazy to think of good ones."

--- a/README.md
+++ b/README.md
@@ -9,13 +9,19 @@ This repository contains microagents for OpenHands AI assistant.
 - **Description**: Tells a random joke when triggered
 - **Trigger**: `tell-me-a-joke`
 
+### Funny Story
+- **File**: `.openhands/microagents/funny-story.md`
+- **Description**: Tells a funny story when triggered
+- **Trigger**: `funny-story`
+
 ## How to Use
 
 To use a microagent, simply use its trigger phrase when talking to OpenHands.
 
-Example:
+Examples:
 ```
 tell-me-a-joke
+funny-story
 ```
 
 ## Adding New Microagents
@@ -31,7 +37,9 @@ tell-me-a-joke
 .
 ├── .openhands/
 │   └── microagents/
-│       └── tell-me-a-joke.md
+│       ├── tell-me-a-joke.md
+│       └── funny-story.md
 ├── README.md
-└── tell-me-a-joke -> .openhands/microagents/tell-me-a-joke.md
+├── tell-me-a-joke -> .openhands/microagents/tell-me-a-joke.md
+└── funny-story -> .openhands/microagents/funny-story.md
 ```

--- a/funny-story
+++ b/funny-story
@@ -1,0 +1,1 @@
+.openhands/microagents/funny-story.md


### PR DESCRIPTION
## Summary

This PR adds a new microagent called "funny-story" that tells funny stories when triggered.

## Changes Made

- ✅ Created new microagent file: `.openhands/microagents/funny-story.md`
- ✅ Added trigger `funny-story` with collection of 5 funny stories
- ✅ Created symbolic link `funny-story` in root directory following existing pattern
- ✅ Updated `README.md` with new microagent documentation
- ✅ Updated repository structure diagram and usage examples

## Usage

Users can now trigger funny stories by using:
```
funny-story
```

## Testing

The microagent follows the same structure and pattern as the existing `tell-me-a-joke` microagent and should work seamlessly with the OpenHands system.

## Files Changed

- `.openhands/microagents/funny-story.md` (new)
- `funny-story` (new symbolic link)
- `README.md` (updated documentation)

The implementation follows the established patterns in the repository and maintains consistency with the existing microagent structure.