### PR TITLE
Update funny-story microagent to include story-teller trigger

### DIFF
--- a/.openhands/microagents/funny-story.md
+++ b/.openhands/microagents/funny-story.md
@@ -1,6 +1,7 @@
 ---
 triggers:
   - funny-story
+  - story-teller
 ---
 
 Tell me a funny story


### PR DESCRIPTION
## Summary

This PR updates the `funny-story` microagent to include an additional trigger `story-teller`, allowing users to activate the microagent using either trigger.

## Changes Made

- Added `story-teller` as an additional trigger for the funny-story microagent
- The microagent can now be triggered by both `funny-story` and `story-teller`
- Maintains the same functionality: telling funny stories

## Files Modified

- `.openhands/microagents/funny-story.md` - Updated triggers list

## Testing

The microagent should now respond to both:
- `funny-story`
- `story-teller`

Both triggers will execute the same functionality: "Tell me a funny story"