### PR TITLE
Update great-story microagent to include story-teller trigger

### DIFF
--- a/.openhands/microagents/great-story.md
+++ b/.openhands/microagents/great-story.md
@@ -1,6 +1,7 @@
 ---
 triggers:
 - great-story
+- story-teller
 ---
 
 # Great Story Teller


### PR DESCRIPTION
## Summary

This PR updates the great-story microagent to include an additional trigger `story-teller` alongside the existing `great-story` trigger.

## Changes Made

- Added `story-teller` to the triggers list in `.openhands/microagents/great-story.md`
- The microagent can now be triggered by both `great-story` and `story-teller` keywords

## Purpose

This enhancement allows users to trigger the Great Story Teller microagent using either trigger phrase, providing more flexibility and intuitive access to the storytelling functionality.

## Testing

The microagent content remains unchanged - only the trigger configuration has been updated to include the additional trigger option.